### PR TITLE
feat: add zip archive download for selected LoRA training images

### DIFF
--- a/packages/api/src/features/fal.ts
+++ b/packages/api/src/features/fal.ts
@@ -86,6 +86,48 @@ export const falRouter = router({
       };
     }),
 
+  downloadImageZip: publicProcedure
+    .input(
+      z.object({
+        imageUrls: z.array(z.string().url()).min(1).max(20),
+        triggerWord: z.string().min(1).max(50),
+      })
+    )
+    .mutation(async ({ input }) => {
+      try {
+        console.log(
+          `Creating downloadable zip file from ${input.imageUrls.length} images...`
+        );
+
+        // Create zip file from images
+        const zipBuffer = await createImageZip(input.imageUrls);
+
+        console.log(`Zip file created (${zipBuffer.length} bytes)`);
+
+        // Convert buffer to base64 for transport
+        const base64Zip = zipBuffer.toString("base64");
+
+        // Generate filename with trigger word and timestamp
+        const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+        const filename = `lora-training-${input.triggerWord}-${timestamp}.zip`;
+
+        return {
+          success: true,
+          filename,
+          data: base64Zip,
+          size: zipBuffer.length,
+          imageCount: input.imageUrls.length,
+        };
+      } catch (error) {
+        console.error("Zip download error:", error);
+        throw new Error(
+          `Failed to create zip archive: ${
+            error instanceof Error ? error.message : "Unknown error"
+          }`
+        );
+      }
+    }),
+
   trainLora: publicProcedure
     .input(
       z.object({


### PR DESCRIPTION
✨ New Features:
- Add downloadImageZip API endpoint to create zip archives from image URLs
- Add download button in UI alongside Train LoRA button
- Generate descriptive filenames with trigger word and timestamp
- Convert base64 zip data to blob for browser download

🔧 Technical Details:
- Backend: New tRPC mutation in fal.ts using existing createImageZip helper
- Frontend: Download button with loading states and error handling
- File naming: lora-training-{triggerWord}-{timestamp}.zip format
- Validates selected images and trigger word before download

🎯 User Experience:
- Users can now download zip archives of selected images locally
- Success/error feedback with clear status messages
- Automatic browser download to Downloads folder